### PR TITLE
`go.mod`のGoバージョン指定を修正


### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module tokitomo-backend
 
-go 1.23.2
+go 1.23
 
 require (
 	github.com/bytedance/sonic v1.12.5 // indirect


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- `go.mod`ファイルのGoバージョン指定を`1.23.2`から`1.23`に変更しました。


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.mod</strong><dd><code>Fix Go version in `go.mod`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

go.mod

- Goのバージョン指定を`1.23.2`から`1.23`に変更しました。


</details>


  </td>
  <td><a href="https://github.com/Shion-Serizawa/tokitomo-backend/pull/13/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information