### PR TITLE
💚Studio上でpostgresが動かなかったので修正

### DIFF
--- a/dev_enviroment/docker/docker-compose.yml
+++ b/dev_enviroment/docker/docker-compose.yml
@@ -15,6 +15,8 @@ services:
     volumes:
       - ./volumes/db/data:/var/lib/postgresql/data:Z
     restart: unless-stopped
+    ports:
+      - "5433:5432"  # ホストの5433をコンテナの5432にマッピング
 
   meta:
     image: supabase/postgres-meta:v0.84.2
@@ -30,7 +32,23 @@ services:
       PG_META_DB_USER: postgres
       PG_META_DB_PASSWORD: ${POSTGRES_PASSWORD}
     ports:
-      - "8080:8080"
+      - "8080:8080"  # ホストの8080を使用
+    restart: unless-stopped
+
+  rest:
+    image: postgrest/postgrest:v12.2.0
+    container_name: supabase-rest
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      PGRST_DB_URI: postgres://postgres:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+      PGRST_DB_SCHEMAS: public
+      PGRST_DB_ANON_ROLE: anon
+      PGRST_JWT_SECRET: ${JWT_SECRET}
+    ports:
+      - "3001:3000"  # ホストの3001をコンテナの3000にマッピング
+    command: ["postgrest"]
     restart: unless-stopped
 
   auth:
@@ -42,13 +60,13 @@ services:
     environment:
       GOTRUE_API_HOST: 0.0.0.0
       GOTRUE_API_PORT: 9999
-      API_EXTERNAL_URL: http://localhost:9999
+      API_EXTERNAL_URL: http://localhost:9998  # ホスト側のポートを9998に変更
       GOTRUE_DB_DRIVER: postgres
       GOTRUE_DB_DATABASE_URL: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
-      GOTRUE_SITE_URL: http://localhost:8081 # studioのポートに変更
+      GOTRUE_SITE_URL: http://localhost:3001
       GOTRUE_JWT_SECRET: ${JWT_SECRET}
     ports:
-      - "9999:9999"
+      - "9998:9999"  # ホストの9998をコンテナの9999にマッピング
     restart: unless-stopped
 
   studio:
@@ -61,14 +79,14 @@ services:
         condition: service_healthy
     environment:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-      SUPABASE_ANON_KEY: super-secret-anon # 必要に応じて変更
-      SUPABASE_SERVICE_KEY: super-secret-service # 必要に応じて変更
+      SUPABASE_ANON_KEY: ${SUPABASE_ANON_KEY}
+      SUPABASE_SERVICE_KEY: ${SUPABASE_SERVICE_KEY}
       STUDIO_PG_META_URL: http://meta:8080
-      SUPABASE_URL: http://localhost:8085 # studioのポートに変更
-      SUPABASE_PUBLIC_URL: http://localhost:8085 # studioのポートに変更
+      SUPABASE_URL: http://localhost:3001
+      SUPABASE_PUBLIC_URL: http://localhost:3001
       AUTH_JWT_SECRET: ${JWT_SECRET}
     ports:
-      - "8085:3000"
+      - "8085:3000"  # ホストの8085をコンテナの3000にマッピング
     restart: unless-stopped
 
   redis:


### PR DESCRIPTION
### **User description**
o1-miniを使って修正．たぶん，ポートが違った．


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- ポートマッピングを修正し、Postgres、REST、Auth、Studioサービスがホストマシンからアクセス可能に。

- `db`サービスにホストポート5433からコンテナポート5432へのマッピングを追加。

- `rest`サービスを追加し、ホストポート3001からコンテナポート3000へのマッピングを設定。

- `auth`サービスの`API_EXTERNAL_URL`を`http://localhost:9998`に、`GOTRUE_SITE_URL`を`http://localhost:3001`に修正。

- `studio`サービスの`SUPABASE_URL`と`SUPABASE_PUBLIC_URL`を`http://localhost:3001`に修正。


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Docker Composeのポート設定とRESTサービス追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dev_enviroment/docker/docker-compose.yml

<li><code>db</code>サービスにポートマッピング <code>5433:5432</code> を追加。<br> <li> <code>rest</code>サービスを追加し、ポートマッピング <code>3001:3000</code> を設定。<br> <li> <code>auth</code>サービスのポートマッピングを <code>9998:9999</code> に変更し、<code>API_EXTERNAL_URL</code>と<code>GOTRUE_SITE_URL</code>を修正。<br> <li> <code>studio</code>サービスの<code>SUPABASE_URL</code>と<code>SUPABASE_PUBLIC_URL</code>を修正し、ポートマッピング <code>8085:3000</code> <br>を設定。


</details>


  </td>
  <td><a href="https://github.com/Shion-Serizawa/tokitomo-backend/pull/16/files#diff-f44d7902054ef83f7b4f719bf6c258e92249ecd31443cebd57ee87e174cc9b18">+28/-10</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>